### PR TITLE
Add test for string errors in traces

### DIFF
--- a/agent_eval/core/input_detector.py
+++ b/agent_eval/core/input_detector.py
@@ -221,9 +221,17 @@ class SmartInputDetector:
         
         elif input_type == "trace":
             # Extract failure patterns for similar testing
+            error_data = input_data.get("error", {})
+            if isinstance(error_data, dict):
+                error_type = error_data.get("type", "unknown")
+                error_message = error_data.get("message", "")
+            else:
+                error_type = error_data
+                error_message = str(error_data)
+
             prepared["failure_info"] = {
-                "error_type": input_data.get("error", {}).get("type", "unknown"),
-                "error_message": input_data.get("error", {}).get("message", ""),
+                "error_type": error_type,
+                "error_message": error_message,
                 "failed_step": input_data.get("failed_step", ""),
                 "framework": self._detect_framework(input_data)
             }

--- a/tests/test_test_harness.py
+++ b/tests/test_test_harness.py
@@ -124,6 +124,24 @@ class TestSmartInputDetector:
         }
         assert detector.get_detected_domain(ml_data) == "ml"
 
+    def test_prepare_trace_with_string_error(self):
+        """Handle trace preparation when error is a simple string."""
+        detector = SmartInputDetector()
+
+        trace = {"error": "Tool call failed"}
+
+        input_type = detector.detect_input_type(trace)
+        assert input_type == "trace"
+
+        prepared = detector.prepare_for_test_harness(trace, input_type)
+
+        assert "failure_info" in prepared
+        failure_info = prepared["failure_info"]
+        assert (
+            failure_info.get("error_message") == "Tool call failed"
+            or failure_info.get("error_type") == "Tool call failed"
+        )
+
 
 class TestDomainAwareTestHarness:
     """Test domain-aware test harness functionality."""


### PR DESCRIPTION
## Summary
- handle string values for `error` when preparing traces
- test preparing a trace with a string error message

## Testing
- `pytest -q tests/test_test_harness.py::TestSmartInputDetector::test_prepare_trace_with_string_error -q` *(fails: ModuleNotFoundError: No module named 'rich')*

------
https://chatgpt.com/codex/tasks/task_e_6840bf70d5e483239a1bbfaa06bf4085